### PR TITLE
Lifecycle tests and minor bug fixes

### DIFF
--- a/Editor/CustomEditors/TerminalEditor.cs
+++ b/Editor/CustomEditors/TerminalEditor.cs
@@ -1,4 +1,4 @@
-﻿namespace DxCommandTerminal.Editor.CustomEditors
+﻿namespace CommandTerminal.Editor.CustomEditors
 {
 #if UNITY_EDITOR
     using System;

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This is a fork of [Command Terminal](https://github.com/stillwwater/command_term
 - Minor performance benefits around using string interpolation and intelligent checking of parameters to only force `string.Format` when relevant in logging paths
 - Better invalid command identification and error messages
 - All string comparisons are now `OrdinalIgnoreCase` instead of relying on CurrentCulture
-- `Terminal` has been made to be Editor-Aware. If the Editor is in Play mode, changes to the current terminal will take effect immediately. If the terminal is open, it will be closed, to prevent bugs.
+- `Terminal` has been made to be Editor-Change-Aware. If the Editor is in Play mode, changes to the current terminal properties will take effect immediately.
 - Extra input validation has been added on all public methods, such that user code is sanitized where appropriate, or rejected if invalid.
 - The concept of "FrontCommands" has been exterminated
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This is a fork of [Command Terminal](https://github.com/stillwwater/command_term
 - Minor performance benefits around using string interpolation and intelligent checking of parameters to only force `string.Format` when relevant in logging paths
 - Better invalid command identification and error messages
 - All string comparisons are now `OrdinalIgnoreCase` instead of relying on CurrentCulture
-- `Terminal` has been made to be Editor-Change-Aware. If the Editor is in Play mode, changes to the current terminal properties will take effect immediately.
+- `Terminal` has been made to be Editor-Change-Aware. If the Editor is in Play mode, changes to the current terminal properties will take effect immediately. This functionality has a minor performance hit and can be disabled via un-checking `Track Changes In Editor` under the `System` header.
 - Extra input validation has been added on all public methods, such that user code is sanitized where appropriate, or rejected if invalid.
 - The concept of "FrontCommands" has been exterminated
 
@@ -340,3 +340,5 @@ See [Unity docs on Managed Stripping Level](https://docs.unity3d.com/2022.3/Docu
 AutoComplete has gotten a major upgrade in this fork. Completion is now not only case-insensitive, but it will now also search (unique) commands that have been executed, ignoring any irrelevant input. Pressing the complete key multiple times now selects available options in a persistent fashion. Completion can be walked both forward and backwards. Results are now presented in a new UI that intelligently adapts to screen space and current selection position. When completion is no longer relevant, the UI is disabled. However, you can opt to always show the available commands by toggling the new `Display Hints` option in the Terminal configuration. There are also several new theming options for hints, with controls over the currently selected hint v unselected hints.
 
 ![png](./Media/AutoComplete.png)
+
+**Note**: Currently, if `Make Hints Clickable` is checked, there is a minor bug where, occasionally, for ~1 frame after auto-completing or deleting a character from a completed word, the text is selected and then unselected. I think it's something to do with the Layout v Repaint events, but I've tried a lot of solutions and none of them worked. Marking this as "won't fix" for now. Open to PRs!

--- a/Runtime/Attributes/RegisterCommandAttribute.cs
+++ b/Runtime/Attributes/RegisterCommandAttribute.cs
@@ -15,6 +15,8 @@ namespace Attributes
         // Should not be used by client code - internal flag to indicate that this is a "Default", or in-built command
         public bool Default { get; set; }
 
+        public bool EditorOnly { get; set; }
+
         public RegisterCommandAttribute(string commandName = null)
         {
             commandName = commandName?.Replace(" ", string.Empty)?.Trim();

--- a/Runtime/CommandTerminal/BuiltinCommands.cs
+++ b/Runtime/CommandTerminal/BuiltinCommands.cs
@@ -8,7 +8,12 @@ namespace CommandTerminal
     // ReSharper disable once UnusedType.Global
     public static class BuiltInCommands
     {
-        [RegisterCommand(Help = "Clear the command console", MaxArgCount = 0, Default = true)]
+        [RegisterCommand(
+            Name = "clear",
+            Help = "Clear the command console",
+            MaxArgCount = 0,
+            Default = true
+        )]
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable once UnusedParameter.Local
         public static void CommandClear(CommandArg[] args)
@@ -17,8 +22,8 @@ namespace CommandTerminal
         }
 
         [RegisterCommand(
-            Help = "Clear the command console's history",
             Name = "clear-history",
+            Help = "Clear the command console's history",
             MaxArgCount = 0,
             Default = true
         )]
@@ -30,6 +35,7 @@ namespace CommandTerminal
         }
 
         [RegisterCommand(
+            Name = "help",
             Help = "Display help information about a command",
             MaxArgCount = 1,
             Default = true
@@ -74,7 +80,12 @@ namespace CommandTerminal
             }
         }
 
-        [RegisterCommand(Help = "Time the execution of a command", MinArgCount = 1, Default = true)]
+        [RegisterCommand(
+            Name = "time",
+            Help = "Time the execution of a command",
+            MinArgCount = 1,
+            Default = true
+        )]
         // ReSharper disable once UnusedMember.Local
         public static void CommandTime(CommandArg[] args)
         {
@@ -90,14 +101,18 @@ namespace CommandTerminal
             Terminal.Log($"Time: {sw.ElapsedMilliseconds}ms");
         }
 
-        [RegisterCommand(Help = "Output message via Terminal.Log", Default = true)]
+        [RegisterCommand(
+            Name = "terminal-log",
+            Help = "Output message via Terminal.Log",
+            Default = true
+        )]
         // ReSharper disable once UnusedMember.Local
         public static void CommandPrint(CommandArg[] args)
         {
             Terminal.Log(JoinArguments(args));
         }
 
-        [RegisterCommand(Help = "Output message via Debug.Log", Default = true)]
+        [RegisterCommand(Name = "log", Help = "Output message via Debug.Log", Default = true)]
         // ReSharper disable once UnusedMember.Local
         public static void CommandLog(CommandArg[] args)
         {
@@ -105,6 +120,7 @@ namespace CommandTerminal
         }
 
         [RegisterCommand(
+            Name = "trace",
             Help = "Output the stack trace of the previous message",
             MaxArgCount = 0,
             Default = true
@@ -136,7 +152,11 @@ namespace CommandTerminal
             );
         }
 
-        [RegisterCommand(Help = "List all variables or set a variable value", Default = true)]
+        [RegisterCommand(
+            Name = "set",
+            Help = "List all variables or set a variable value",
+            Default = true
+        )]
         // ReSharper disable once UnusedMember.Global
         // ReSharper disable once UnusedMember.Local
         public static void CommandSet(CommandArg[] args)
@@ -169,15 +189,20 @@ namespace CommandTerminal
             shell.SetVariable(variableName, JoinArguments(args, 1));
         }
 
-        [RegisterCommand(Help = "No operation", Default = true)]
+        [RegisterCommand(Name = "no-op", Help = "No operation", Default = true)]
         // ReSharper disable once UnusedParameter.Local
         // ReSharper disable once UnusedMember.Local
-        public static void CommandNoop(CommandArg[] args)
+        public static void CommandNoOperation(CommandArg[] args)
         {
             // No-op
         }
 
-        [RegisterCommand(Help = "Quit running application", MaxArgCount = 0, Default = true)]
+        [RegisterCommand(
+            Name = "quit",
+            Help = "Quit running application",
+            MaxArgCount = 0,
+            Default = true
+        )]
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable once UnusedParameter.Local
         public static void CommandQuit(CommandArg[] args)

--- a/Runtime/CommandTerminal/BuiltinCommands.cs
+++ b/Runtime/CommandTerminal/BuiltinCommands.cs
@@ -52,7 +52,7 @@ namespace CommandTerminal
                 return;
             }
 
-            string commandName = args[0].String ?? string.Empty;
+            string commandName = args[0].contents ?? string.Empty;
 
             if (!shell.Commands.TryGetValue(commandName, out CommandInfo info))
             {
@@ -156,7 +156,7 @@ namespace CommandTerminal
                 return;
             }
 
-            string variableName = args[0].String;
+            string variableName = args[0].contents;
 
             if (variableName[0] == '$')
             {
@@ -194,7 +194,7 @@ namespace CommandTerminal
             StringBuilder sb = new();
             for (int i = start; i < args.Length; i++)
             {
-                sb.Append(args[i].String);
+                sb.Append(args[i].contents);
 
                 if (i < args.Length - 1)
                 {

--- a/Runtime/CommandTerminal/CommandArg.cs
+++ b/Runtime/CommandTerminal/CommandArg.cs
@@ -1,0 +1,608 @@
+﻿namespace CommandTerminal
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using UnityEngine;
+
+    public delegate bool CommandArgParser<T>(string input, out T parsed);
+
+    public readonly struct CommandArg
+    {
+        private static readonly Lazy<MethodInfo> TryGetMethod = new(
+            () =>
+                typeof(CommandArg)
+                    .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(method => method.Name == nameof(TryGet))
+                    .FirstOrDefault(method => method.GetParameters().Length == 1)
+        );
+        private static readonly Dictionary<Type, object> RegisteredParsers = new();
+        private static readonly Dictionary<
+            Type,
+            Dictionary<string, PropertyInfo>
+        > StaticProperties = new();
+        private static readonly Dictionary<Type, Dictionary<string, FieldInfo>> ConstFields = new();
+        private static readonly Dictionary<Type, object> EnumValues = new();
+
+        // Public to allow custom-mutation, if desired
+        public static readonly HashSet<char> Delimiters = new() { ',', ';', ':', '_', '/', '\\' };
+        public static readonly List<char> Quotes = new() { '"', '\'' };
+        public static readonly HashSet<string> IgnoredValuesForCleanedTypes = new() { "\r", "\n" };
+        public static readonly HashSet<Type> DoNotCleanTypes = new()
+        {
+            typeof(string),
+            typeof(char),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+        };
+        public static readonly HashSet<string> IgnoredValuesForComplexTypes = new()
+        {
+            "(",
+            ")",
+            "[",
+            "]",
+            "'",
+            "`",
+            "|",
+            "{",
+            "}",
+            "<",
+            ">",
+        };
+
+        public readonly string contents;
+        public readonly char? startQuote;
+        public readonly char? endQuote;
+
+        public string CleanedContents
+        {
+            get
+            {
+                string cleanedString = contents;
+                cleanedString = IgnoredValuesForCleanedTypes.Aggregate(
+                    cleanedString,
+                    (current, ignoredValue) =>
+                        current.Replace(
+                            ignoredValue,
+                            string.Empty,
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                );
+                return cleanedString;
+            }
+        }
+
+        public bool TryGet(Type type, out object parsed)
+        {
+            // TODO: Convert into delegates and cache for performance
+            MethodInfo genericMethod = TryGetMethod.Value;
+            if (genericMethod == null)
+            {
+                parsed = default;
+                return false;
+            }
+
+            MethodInfo constructed = genericMethod.MakeGenericMethod(type);
+            object[] parameters = { null };
+            bool success = (bool)constructed.Invoke(this, parameters);
+            parsed = parameters[0];
+            return success;
+        }
+
+        public bool TryGet<T>(out T parsed)
+        {
+            return TryGet(out parsed, parserOverride: null);
+        }
+
+        public bool TryGet<T>(out T parsed, CommandArgParser<T> parserOverride)
+        {
+            Type type = typeof(T);
+            string stringValue = DoNotCleanTypes.Contains(type) ? contents : CleanedContents;
+
+            if (parserOverride != null)
+            {
+                return parserOverride(stringValue, out parsed);
+            }
+
+            if (TryGetParser(out CommandArgParser<T> parser))
+            {
+                return parser(stringValue, out parsed);
+            }
+
+            if (type == typeof(string))
+            {
+                parsed = (T)Convert.ChangeType(stringValue, type);
+                return true;
+            }
+            if (TryGetTypeDefined(stringValue, out parsed))
+            {
+                return true;
+            }
+
+            // TODO: Slap into a dictionary of built-in type -> parser mapping
+            if (type == typeof(bool))
+            {
+                return InnerParse<bool>(stringValue, bool.TryParse, out parsed);
+            }
+            if (type == typeof(float))
+            {
+                return InnerParse<float>(stringValue, float.TryParse, out parsed);
+            }
+            if (type == typeof(int))
+            {
+                return InnerParse<int>(stringValue, int.TryParse, out parsed);
+            }
+            if (type == typeof(uint))
+            {
+                return InnerParse<uint>(stringValue, uint.TryParse, out parsed);
+            }
+            if (type == typeof(long))
+            {
+                return InnerParse<long>(stringValue, long.TryParse, out parsed);
+            }
+            if (type == typeof(ulong))
+            {
+                return InnerParse<ulong>(stringValue, ulong.TryParse, out parsed);
+            }
+            if (type == typeof(double))
+            {
+                return InnerParse<double>(stringValue, double.TryParse, out parsed);
+            }
+            if (type == typeof(short))
+            {
+                return InnerParse<short>(stringValue, short.TryParse, out parsed);
+            }
+            if (type == typeof(ushort))
+            {
+                return InnerParse<ushort>(stringValue, ushort.TryParse, out parsed);
+            }
+            if (type == typeof(byte))
+            {
+                return InnerParse<byte>(stringValue, byte.TryParse, out parsed);
+            }
+            if (type == typeof(sbyte))
+            {
+                return InnerParse<sbyte>(stringValue, sbyte.TryParse, out parsed);
+            }
+            if (type == typeof(Guid))
+            {
+                return InnerParse<Guid>(stringValue, Guid.TryParse, out parsed);
+            }
+            if (type == typeof(DateTime))
+            {
+                return InnerParse<DateTime>(stringValue, DateTime.TryParse, out parsed);
+            }
+            if (type == typeof(DateTimeOffset))
+            {
+                return InnerParse<DateTimeOffset>(stringValue, DateTimeOffset.TryParse, out parsed);
+            }
+            if (type == typeof(char))
+            {
+                return InnerParse<char>(stringValue, char.TryParse, out parsed);
+            }
+            if (type == typeof(decimal))
+            {
+                return InnerParse<decimal>(stringValue, decimal.TryParse, out parsed);
+            }
+            if (type.IsEnum)
+            {
+                if (Enum.IsDefined(type, stringValue))
+                {
+                    bool parseOk = Enum.TryParse(type, stringValue, out object parsedObject);
+                    if (parseOk)
+                    {
+                        parsed = (T)Convert.ChangeType(parsedObject, type);
+                        return true;
+                    }
+                }
+
+                if (int.TryParse(stringValue, out int enumIntValue))
+                {
+                    if (!EnumValues.TryGetValue(type, out object enumValues))
+                    {
+                        enumValues = Enum.GetValues(type).OfType<T>().ToArray();
+                        EnumValues[type] = enumValues;
+                    }
+
+                    T[] values = (T[])enumValues;
+                    if (0 <= enumIntValue && enumIntValue < values.Length)
+                    {
+                        parsed = values[enumIntValue];
+                        return true;
+                    }
+                }
+            }
+            if (type == typeof(Vector2))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 2
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y):
+                        parsed = (T)Convert.ChangeType(new Vector2(x, y), type);
+                        return true;
+                    case 3
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y)
+                            && float.TryParse(split[2], out float z):
+                        parsed = (T)Convert.ChangeType((Vector2)new Vector3(x, y, z), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Vector3))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 2
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y):
+                        parsed = (T)Convert.ChangeType(new Vector3(x, y), type);
+                        return true;
+                    case 3
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y)
+                            && float.TryParse(split[2], out float z):
+                        parsed = (T)Convert.ChangeType(new Vector3(x, y, z), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Vector4))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 2
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y):
+                        parsed = (T)Convert.ChangeType(new Vector4(x, y), type);
+                        return true;
+                    case 3
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y)
+                            && float.TryParse(split[2], out float z):
+                        parsed = (T)Convert.ChangeType(new Vector4(x, y, z), type);
+                        return true;
+                    case 4
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y)
+                            && float.TryParse(split[2], out float z)
+                            && float.TryParse(split[3], out float w):
+                        parsed = (T)Convert.ChangeType(new Vector4(x, y, z, w), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Vector2Int))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 2
+                        when int.TryParse(split[0], out int x) && int.TryParse(split[1], out int y):
+                        parsed = (T)Convert.ChangeType(new Vector2Int(x, y), type);
+                        return true;
+                    case 3
+                        when int.TryParse(split[0], out int x)
+                            && int.TryParse(split[1], out int y)
+                            && int.TryParse(split[2], out int z):
+                        parsed = (T)Convert.ChangeType((Vector2Int)new Vector3Int(x, y, z), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Vector3Int))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 2
+                        when int.TryParse(split[0], out int x) && int.TryParse(split[1], out int y):
+                        parsed = (T)Convert.ChangeType(new Vector3Int(x, y), type);
+                        return true;
+                    case 3
+                        when int.TryParse(split[0], out int x)
+                            && int.TryParse(split[1], out int y)
+                            && int.TryParse(split[2], out int z):
+                        parsed = (T)Convert.ChangeType(new Vector3Int(x, y, z), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Color))
+            {
+                string colorString = stringValue;
+                if (colorString.StartsWith("RGBA", StringComparison.OrdinalIgnoreCase))
+                {
+                    colorString = colorString.Replace(
+                        "RGBA",
+                        string.Empty,
+                        StringComparison.OrdinalIgnoreCase
+                    );
+                }
+
+                string[] split = StripAndSplit(colorString);
+                switch (split.Length)
+                {
+                    case 3
+                        when float.TryParse(split[0], out float r)
+                            && float.TryParse(split[1], out float g)
+                            && float.TryParse(split[2], out float b):
+                        parsed = (T)Convert.ChangeType(new Color(r, g, b), type);
+                        return true;
+                    case 4
+                        when float.TryParse(split[0], out float r)
+                            && float.TryParse(split[1], out float g)
+                            && float.TryParse(split[2], out float b)
+                            && float.TryParse(split[3], out float a):
+                        parsed = (T)Convert.ChangeType(new Color(r, g, b, a), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Quaternion))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 4
+                        when float.TryParse(split[0], out float x)
+                            && float.TryParse(split[1], out float y)
+                            && float.TryParse(split[2], out float z)
+                            && float.TryParse(split[3], out float w):
+                        parsed = (T)Convert.ChangeType(new Quaternion(x, y, z, w), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(Rect))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 4
+                        when float.TryParse(
+                            split[0]
+                                .Replace("x:", string.Empty, StringComparison.OrdinalIgnoreCase),
+                            out float x
+                        )
+                            && float.TryParse(
+                                split[1]
+                                    .Replace(
+                                        "y:",
+                                        string.Empty,
+                                        StringComparison.OrdinalIgnoreCase
+                                    ),
+                                out float y
+                            )
+                            && float.TryParse(
+                                split[2]
+                                    .Replace(
+                                        "width:",
+                                        string.Empty,
+                                        StringComparison.OrdinalIgnoreCase
+                                    ),
+                                out float width
+                            )
+                            && float.TryParse(
+                                split[3]
+                                    .Replace(
+                                        "height:",
+                                        string.Empty,
+                                        StringComparison.OrdinalIgnoreCase
+                                    ),
+                                out float height
+                            ):
+                        parsed = (T)Convert.ChangeType(new Rect(x, y, width, height), type);
+                        return true;
+                }
+            }
+            else if (type == typeof(RectInt))
+            {
+                string[] split = StripAndSplit(stringValue);
+                switch (split.Length)
+                {
+                    case 4
+                        when int.TryParse(
+                            split[0]
+                                .Replace("x:", string.Empty, StringComparison.OrdinalIgnoreCase),
+                            out int x
+                        )
+                            && int.TryParse(
+                                split[1]
+                                    .Replace(
+                                        "y:",
+                                        string.Empty,
+                                        StringComparison.OrdinalIgnoreCase
+                                    ),
+                                out int y
+                            )
+                            && int.TryParse(
+                                split[2]
+                                    .Replace(
+                                        "width:",
+                                        string.Empty,
+                                        StringComparison.OrdinalIgnoreCase
+                                    ),
+                                out int width
+                            )
+                            && int.TryParse(
+                                split[3]
+                                    .Replace(
+                                        "height:",
+                                        string.Empty,
+                                        StringComparison.OrdinalIgnoreCase
+                                    ),
+                                out int height
+                            ):
+                        parsed = (T)Convert.ChangeType(new RectInt(x, y, width, height), type);
+                        return true;
+                }
+            }
+
+            parsed = default;
+            return false;
+
+            static bool InnerParse<TParsed>(
+                string input,
+                CommandArgParser<TParsed> typedParser,
+                out T parsed
+            )
+            {
+                bool parseOk = typedParser(input, out TParsed value);
+                if (parseOk)
+                {
+                    parsed = (T)Convert.ChangeType(value, typeof(T));
+                }
+                else
+                {
+                    parsed = default;
+                }
+
+                return parseOk;
+            }
+
+            static string[] StripAndSplit(string input)
+            {
+                string strippedInput = IgnoredValuesForComplexTypes
+                    .Where(ignored => !string.IsNullOrEmpty(ignored))
+                    .Aggregate(
+                        input,
+                        (current, ignored) =>
+                            current.Replace(
+                                ignored,
+                                string.Empty,
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                    );
+
+                foreach (char delimiter in Delimiters)
+                {
+                    if (strippedInput.Contains(delimiter))
+                    {
+                        return strippedInput.Split(delimiter);
+                    }
+                }
+
+                return new[] { strippedInput };
+            }
+
+            static bool TryGetTypeDefined(string input, out T value)
+            {
+                Type type = typeof(T);
+                if (
+                    !StaticProperties.TryGetValue(
+                        type,
+                        out Dictionary<string, PropertyInfo> properties
+                    )
+                )
+                {
+                    properties = LoadStaticPropertiesForType<T>();
+                    StaticProperties[type] = properties;
+                }
+
+                if (properties.TryGetValue(input, out PropertyInfo property))
+                {
+                    object resolved = property.GetValue(null);
+                    value = (T)Convert.ChangeType(resolved, type);
+                    return true;
+                }
+
+                if (!ConstFields.TryGetValue(type, out Dictionary<string, FieldInfo> fields))
+                {
+                    fields = LoadStaticFieldsForType<T>();
+                    ConstFields[type] = fields;
+                }
+
+                if (fields.TryGetValue(input, out FieldInfo field))
+                {
+                    object resolved = field.GetValue(null);
+                    value = (T)Convert.ChangeType(resolved, type);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+        }
+
+        public CommandArg(string contents, char? startQuote = null, char? endQuote = null)
+        {
+            this.contents = contents ?? string.Empty;
+            this.startQuote = startQuote;
+            this.endQuote = endQuote;
+        }
+
+        public static bool RegisterParser<T>(CommandArgParser<T> parser, bool force = false)
+        {
+            if (parser == null)
+            {
+                return false;
+            }
+
+            Type type = typeof(T);
+            if (force)
+            {
+                RegisteredParsers[type] = parser;
+                return true;
+            }
+
+            return RegisteredParsers.TryAdd(type, parser);
+        }
+
+        public static bool TryGetParser<T>(out CommandArgParser<T> parser)
+        {
+            if (RegisteredParsers.TryGetValue(typeof(T), out object untypedParser))
+            {
+                parser = (CommandArgParser<T>)untypedParser;
+                return true;
+            }
+
+            parser = null;
+            return false;
+        }
+
+        public static bool UnregisterParser<T>()
+        {
+            return UnregisterParser(typeof(T));
+        }
+
+        public static bool UnregisterParser(Type type)
+        {
+            return RegisteredParsers.Remove(type);
+        }
+
+        public static int UnregisterAllParsers()
+        {
+            int parserCount = RegisteredParsers.Count;
+            RegisteredParsers.Clear();
+            return parserCount;
+        }
+
+        private static Dictionary<string, PropertyInfo> LoadStaticPropertiesForType<T>()
+        {
+            Type type = typeof(T);
+            return type.GetProperties(BindingFlags.Static | BindingFlags.Public)
+                .Where(property => property.PropertyType == type)
+                .ToDictionary(
+                    property => property.Name,
+                    property => property,
+                    StringComparer.OrdinalIgnoreCase
+                );
+        }
+
+        private static Dictionary<string, FieldInfo> LoadStaticFieldsForType<T>()
+        {
+            Type type = typeof(T);
+            return type.GetFields(BindingFlags.Static | BindingFlags.Public)
+                .Where(field => field.FieldType == type)
+                .ToDictionary(
+                    field => field.Name,
+                    field => field,
+                    StringComparer.OrdinalIgnoreCase
+                );
+        }
+
+        public override string ToString()
+        {
+            return contents;
+        }
+    }
+}

--- a/Runtime/CommandTerminal/CommandArg.cs.meta
+++ b/Runtime/CommandTerminal/CommandArg.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 95c38cbb91164878b48bb79ced2b6e7b
+timeCreated: 1741625878

--- a/Runtime/CommandTerminal/CommandHistory.cs
+++ b/Runtime/CommandTerminal/CommandHistory.cs
@@ -1,13 +1,21 @@
 namespace CommandTerminal
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
+    using DataStructures;
 
     public sealed class CommandHistory
     {
-        private readonly List<(string text, bool? success, bool? errorFree)> _history = new();
+        public int Capacity => _history.Capacity;
+
+        private readonly CyclicBuffer<(string text, bool? success, bool? errorFree)> _history;
+
         private int _position;
+
+        public CommandHistory(int capacity)
+        {
+            _history = new CyclicBuffer<(string text, bool? success, bool? errorFree)>(capacity);
+        }
 
         public IEnumerable<string> GetHistory(bool onlySuccess, bool onlyErrorFree)
         {
@@ -15,6 +23,11 @@ namespace CommandTerminal
                 .Where(value => !onlySuccess || value.success == true)
                 .Where(value => !onlyErrorFree || value.errorFree == true)
                 .Select(value => value.text);
+        }
+
+        public void Resize(int newCapacity)
+        {
+            _history.Resize(newCapacity);
         }
 
         public bool Push(string commandString, bool? success, bool? errorFree)
@@ -52,16 +65,6 @@ namespace CommandTerminal
 
             _position = -1;
             return string.Empty;
-        }
-
-        public int Remove(Predicate<(string text, bool? success, bool? errorFree)> acceptance)
-        {
-            if (acceptance == null)
-            {
-                throw new ArgumentNullException(nameof(acceptance));
-            }
-
-            return _history.RemoveAll(acceptance);
         }
 
         public int Clear()

--- a/Runtime/CommandTerminal/CommandHistory.cs
+++ b/Runtime/CommandTerminal/CommandHistory.cs
@@ -1,5 +1,6 @@
 namespace CommandTerminal
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -53,10 +54,22 @@ namespace CommandTerminal
             return string.Empty;
         }
 
-        public void Clear()
+        public int Remove(Predicate<(string text, bool? success, bool? errorFree)> acceptance)
         {
+            if (acceptance == null)
+            {
+                throw new ArgumentNullException(nameof(acceptance));
+            }
+
+            return _history.RemoveAll(acceptance);
+        }
+
+        public int Clear()
+        {
+            int count = _history.Count;
             _history.Clear();
             _position = 0;
+            return count;
         }
     }
 }

--- a/Runtime/CommandTerminal/CommandHistory.cs
+++ b/Runtime/CommandTerminal/CommandHistory.cs
@@ -16,15 +16,16 @@ namespace CommandTerminal
                 .Select(value => value.text);
         }
 
-        public void Push(string commandString, bool? success, bool? errorFree)
+        public bool Push(string commandString, bool? success, bool? errorFree)
         {
             if (string.IsNullOrWhiteSpace(commandString))
             {
-                return;
+                return false;
             }
 
             _history.Add((commandString, success, errorFree));
             _position = _history.Count;
+            return true;
         }
 
         public string Next()

--- a/Runtime/CommandTerminal/CommandInfo.cs
+++ b/Runtime/CommandTerminal/CommandInfo.cs
@@ -1,0 +1,28 @@
+﻿namespace CommandTerminal
+{
+    using System;
+
+    public readonly struct CommandInfo
+    {
+        public readonly Action<CommandArg[]> proc;
+        public readonly int minArgCount;
+        public readonly int maxArgCount;
+        public readonly string help;
+        public readonly string hint;
+
+        public CommandInfo(
+            Action<CommandArg[]> proc,
+            int minArgCount,
+            int maxArgCount,
+            string help,
+            string hint
+        )
+        {
+            this.proc = proc;
+            this.maxArgCount = maxArgCount;
+            this.minArgCount = minArgCount;
+            this.help = help;
+            this.hint = hint;
+        }
+    }
+}

--- a/Runtime/CommandTerminal/CommandInfo.cs.meta
+++ b/Runtime/CommandTerminal/CommandInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bc3bf98cabac47abbcef195823554825
+timeCreated: 1741626042

--- a/Runtime/CommandTerminal/CommandLog.cs
+++ b/Runtime/CommandTerminal/CommandLog.cs
@@ -34,14 +34,16 @@ namespace CommandTerminal
     public sealed class CommandLog
     {
         public IReadOnlyList<LogItem> Logs => _logs;
+        public int Capacity => _logs.Capacity;
+
+        public readonly HashSet<TerminalLogType> ignoredLogTypes;
 
         private readonly CyclicBuffer<LogItem> _logs;
-        private readonly HashSet<TerminalLogType> _ignoredLogTypes;
 
         public CommandLog(int maxItems, IEnumerable<TerminalLogType> ignoredLogTypes = null)
         {
             _logs = new CyclicBuffer<LogItem>(maxItems);
-            _ignoredLogTypes = new HashSet<TerminalLogType>(
+            this.ignoredLogTypes = new HashSet<TerminalLogType>(
                 ignoredLogTypes ?? Enumerable.Empty<TerminalLogType>()
             );
         }
@@ -63,7 +65,7 @@ namespace CommandTerminal
 
         public bool HandleLog(string message, string stackTrace, TerminalLogType type)
         {
-            if (_ignoredLogTypes.Contains(type))
+            if (ignoredLogTypes.Contains(type))
             {
                 return false;
             }
@@ -78,6 +80,11 @@ namespace CommandTerminal
             int logCount = _logs.Count;
             _logs.Clear();
             return logCount;
+        }
+
+        public void Resize(int newCapacity)
+        {
+            _logs.Resize(newCapacity);
         }
     }
 }

--- a/Runtime/CommandTerminal/CommandShell.cs
+++ b/Runtime/CommandTerminal/CommandShell.cs
@@ -21,7 +21,7 @@ namespace CommandTerminal
             const BindingFlags methodFlags =
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 
-            Assembly[] ourAssembly = { typeof(CommandShell).Assembly };
+            Assembly[] ourAssembly = { typeof(BuiltInCommands).Assembly };
             foreach (
                 Type type in AppDomain
                     .CurrentDomain.GetAssemblies()
@@ -278,17 +278,20 @@ namespace CommandTerminal
 
             string line = _commandBuilder.ToString();
 
-            commandName = commandName?.Replace(
-                " ",
-                string.Empty,
-                StringComparison.OrdinalIgnoreCase
-            );
-
             if (string.IsNullOrWhiteSpace(commandName))
             {
                 IssueErrorMessage($"Invalid command name '{commandName}'");
                 // Don't log empty commands
                 return false;
+            }
+
+            if (commandName.Contains(' '))
+            {
+                commandName = commandName.Replace(
+                    " ",
+                    string.Empty,
+                    StringComparison.OrdinalIgnoreCase
+                );
             }
 
             if (!_commands.TryGetValue(commandName, out CommandInfo command))
@@ -344,7 +347,11 @@ namespace CommandTerminal
                 return false;
             }
 
-            name = name.Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase);
+            if (name.Contains(' '))
+            {
+                name = name.Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase);
+            }
+
             if (!_commands.TryAdd(name, info))
             {
                 IssueErrorMessage($"Command {name} is already defined.");
@@ -383,7 +390,11 @@ namespace CommandTerminal
                 return false;
             }
 
-            name = name.Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase);
+            if (name.Contains(' '))
+            {
+                name = name.Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase);
+            }
+
             _variables[name] = value;
             return true;
         }
@@ -391,9 +402,19 @@ namespace CommandTerminal
         // ReSharper disable once UnusedMember.Global
         public bool TryGetVariable(string name, out CommandArg variable)
         {
-            name =
-                name?.Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase)
-                ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                variable = default;
+                return false;
+            }
+
+            if (name.Contains(' '))
+            {
+                name =
+                    name.Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase)
+                    ?? string.Empty;
+            }
+
             return _variables.TryGetValue(name, out variable);
         }
 

--- a/Runtime/CommandTerminal/Terminal.cs
+++ b/Runtime/CommandTerminal/Terminal.cs
@@ -92,7 +92,6 @@ namespace CommandTerminal
         public static CommandLog Buffer { get; private set; }
         public static CommandShell Shell { get; private set; }
 
-        // ReSharper disable once MemberCanBePrivate.Global
         public static CommandHistory History { get; private set; }
 
         // ReSharper disable once MemberCanBePrivate.Global
@@ -240,7 +239,6 @@ namespace CommandTerminal
 #if UNITY_EDITOR
         private readonly Dictionary<TerminalLogType, int> _seenLogTypes = new();
 #endif
-
         private TerminalState _state;
         private TextEditor _editorState;
 #if !ENABLE_INPUT_SYSTEM

--- a/Runtime/CommandTerminal/TerminalState.cs
+++ b/Runtime/CommandTerminal/TerminalState.cs
@@ -1,0 +1,10 @@
+﻿namespace CommandTerminal
+{
+    public enum TerminalState
+    {
+        Unknown = 0,
+        Closed = 1,
+        OpenSmall = 2,
+        OpenFull = 3,
+    }
+}

--- a/Runtime/CommandTerminal/TerminalState.cs.meta
+++ b/Runtime/CommandTerminal/TerminalState.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d0fc5d9508854deeae8f2545cb27301f
+timeCreated: 1741629599

--- a/Runtime/DataStructures/CyclicBuffer.cs
+++ b/Runtime/DataStructures/CyclicBuffer.cs
@@ -1,9 +1,10 @@
-﻿namespace DataStructures
+﻿namespace CommandTerminal.DataStructures
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using Extensions;
 
     [Serializable]
     public sealed class CyclicBuffer<T> : IReadOnlyList<T>
@@ -97,10 +98,13 @@
             {
                 throw new ArgumentException(nameof(newCapacity));
             }
+
             Capacity = newCapacity;
+            _buffer.Shift(-_position);
             if (newCapacity < _buffer.Count)
             {
                 _buffer.RemoveRange(newCapacity, _buffer.Count - newCapacity);
+                _position = 0;
             }
 
             Count = Math.Min(newCapacity, Count);

--- a/Runtime/DataStructures/CyclicBuffer.cs
+++ b/Runtime/DataStructures/CyclicBuffer.cs
@@ -8,10 +8,9 @@
     [Serializable]
     public sealed class CyclicBuffer<T> : IReadOnlyList<T>
     {
+        public int Capacity { get; private set; }
         public int Count { get; private set; }
         public bool IsReadOnly => false;
-
-        public readonly int capacity;
 
         private readonly List<T> _buffer;
         private int _position;
@@ -37,7 +36,7 @@
                 throw new ArgumentException(nameof(capacity));
             }
 
-            this.capacity = capacity;
+            Capacity = capacity;
             _position = 0;
             Count = 0;
             _buffer = new List<T>();
@@ -63,7 +62,7 @@
 
         public void Add(T item)
         {
-            if (capacity == 0)
+            if (Capacity == 0)
             {
                 return;
             }
@@ -77,8 +76,8 @@
                 _buffer.Add(item);
             }
 
-            _position = (_position + 1) % capacity;
-            if (Count < capacity)
+            _position = (_position + 1) % Capacity;
+            if (Count < Capacity)
             {
                 ++Count;
             }
@@ -92,6 +91,23 @@
             _buffer.Clear();
         }
 
+        public void Resize(int newCapacity)
+        {
+            if (newCapacity < 0)
+            {
+                throw new ArgumentException(nameof(newCapacity));
+            }
+            Capacity = newCapacity;
+            if (newCapacity < _buffer.Count)
+            {
+                _buffer.RemoveRange(newCapacity, _buffer.Count - newCapacity);
+            }
+            if (newCapacity < Count)
+            {
+                Count = newCapacity;
+            }
+        }
+
         public bool Contains(T item)
         {
             return _buffer.Contains(item);
@@ -99,7 +115,11 @@
 
         private int AdjustedIndexFor(int index)
         {
-            long longCapacity = capacity;
+            long longCapacity = Capacity;
+            if (longCapacity == 0L)
+            {
+                return 0;
+            }
             unchecked
             {
                 int adjustedIndex = (int)(

--- a/Runtime/DataStructures/CyclicBuffer.cs
+++ b/Runtime/DataStructures/CyclicBuffer.cs
@@ -102,10 +102,8 @@
             {
                 _buffer.RemoveRange(newCapacity, _buffer.Count - newCapacity);
             }
-            if (newCapacity < Count)
-            {
-                Count = newCapacity;
-            }
+
+            Count = Math.Min(newCapacity, Count);
         }
 
         public bool Contains(T item)

--- a/Runtime/Extensions.meta
+++ b/Runtime/Extensions.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b53ad31fd6c54458afbc3ba55183789c
+timeCreated: 1741627511

--- a/Runtime/Extensions/IListExtensions.cs
+++ b/Runtime/Extensions/IListExtensions.cs
@@ -1,0 +1,39 @@
+﻿namespace CommandTerminal.Extensions
+{
+    using System.Collections.Generic;
+
+    public static class IListExtensions
+    {
+        public static void Shift<T>(this IList<T> list, int amount)
+        {
+            int count = list.Count;
+            if (count <= 1)
+            {
+                return;
+            }
+
+            amount %= count;
+            amount += count;
+            amount %= count;
+
+            if (amount == 0)
+            {
+                return;
+            }
+
+            Reverse(list, 0, count - 1);
+            Reverse(list, 0, amount - 1);
+            Reverse(list, amount, count - 1);
+        }
+
+        public static void Reverse<T>(this IList<T> list, int start, int end)
+        {
+            while (start < end)
+            {
+                (list[start], list[end]) = (list[end], list[start]);
+                start++;
+                end--;
+            }
+        }
+    }
+}

--- a/Runtime/Extensions/IListExtensions.cs.meta
+++ b/Runtime/Extensions/IListExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7ed450c68538425d9520a79391e439f8
+timeCreated: 1741905937

--- a/Runtime/Extensions/SerializedPropertyExtensions.cs
+++ b/Runtime/Extensions/SerializedPropertyExtensions.cs
@@ -1,50 +1,156 @@
 ﻿namespace CommandTerminal.Extensions
 {
 #if UNITY_EDITOR
+    using System;
+    using System.Collections.Generic;
     using System.Reflection;
+    using System.Reflection.Emit;
     using UnityEditor;
     using UnityEngine;
 
+    public static class FieldAccessorFactory
+    {
+        public static Func<object, object> CreateFieldGetter(FieldInfo field)
+        {
+            var dynamicMethod = new DynamicMethod(
+                "Get" + field.Name,
+                typeof(object),
+                new[] { typeof(object) },
+                field.DeclaringType,
+                true
+            );
+
+            ILGenerator il = dynamicMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, field.DeclaringType);
+            il.Emit(OpCodes.Ldfld, field);
+            if (field.FieldType.IsValueType)
+            {
+                il.Emit(OpCodes.Box, field.FieldType);
+            }
+
+            il.Emit(OpCodes.Ret);
+
+            return (Func<object, object>)dynamicMethod.CreateDelegate(typeof(Func<object, object>));
+        }
+    }
+
     public static class SerializedPropertyExtensions
     {
+        private static readonly Dictionary<
+            Type,
+            Dictionary<string, Func<object, object>>
+        > FieldProducersByType = new();
+        private static readonly PropertyInfo GradientProperty =
+            typeof(SerializedProperty).GetProperty(
+                "gradientValue",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+            );
+
         public static object GetValue(this SerializedProperty property)
         {
-            return property.propertyType switch
+            switch (property.propertyType)
             {
-                SerializedPropertyType.Integer => property.intValue,
-                SerializedPropertyType.Boolean => property.boolValue,
-                SerializedPropertyType.Float => property.floatValue,
-                SerializedPropertyType.String => property.stringValue,
-                SerializedPropertyType.Color => property.colorValue,
-                SerializedPropertyType.ObjectReference => property.objectReferenceValue,
-                SerializedPropertyType.LayerMask => (LayerMask)property.intValue,
-                SerializedPropertyType.Enum => property.enumValueIndex,
-                SerializedPropertyType.Vector2 => property.vector2Value,
-                SerializedPropertyType.Vector3 => property.vector3Value,
-                SerializedPropertyType.Vector4 => property.vector4Value,
-                SerializedPropertyType.Rect => property.rectValue,
-                SerializedPropertyType.Character => (char)property.intValue,
-                SerializedPropertyType.AnimationCurve => property.animationCurveValue,
-                SerializedPropertyType.Bounds => property.boundsValue,
-                SerializedPropertyType.Gradient => GetGradientValue(property),
-                SerializedPropertyType.Quaternion => property.quaternionValue,
-                SerializedPropertyType.Vector2Int => property.vector2IntValue,
-                SerializedPropertyType.Vector3Int => property.vector3IntValue,
-                SerializedPropertyType.RectInt => property.rectIntValue,
-                SerializedPropertyType.BoundsInt => property.boundsIntValue,
-                SerializedPropertyType.ManagedReference => property.managedReferenceValue,
-                _ => null,
-            };
+                case SerializedPropertyType.Integer:
+                    return property.intValue;
+                case SerializedPropertyType.Boolean:
+                    return property.boolValue;
+                case SerializedPropertyType.Float:
+                    return property.floatValue;
+                case SerializedPropertyType.String:
+                    return property.stringValue;
+                case SerializedPropertyType.Color:
+                    return property.colorValue;
+                case SerializedPropertyType.ObjectReference:
+                    return property.objectReferenceValue;
+                case SerializedPropertyType.LayerMask:
+                    return (LayerMask)property.intValue;
+                case SerializedPropertyType.Enum:
+                    return property.enumValueIndex;
+                case SerializedPropertyType.Vector2:
+                    return property.vector2Value;
+                case SerializedPropertyType.Vector3:
+                    return property.vector3Value;
+                case SerializedPropertyType.Vector4:
+                    return property.vector4Value;
+                case SerializedPropertyType.Rect:
+                    return property.rectValue;
+                case SerializedPropertyType.Character:
+                    return (char)property.intValue;
+                case SerializedPropertyType.AnimationCurve:
+                    return property.animationCurveValue;
+                case SerializedPropertyType.Bounds:
+                    return property.boundsValue;
+                case SerializedPropertyType.Gradient:
+                    return GetGradientValue(property);
+                case SerializedPropertyType.Quaternion:
+                    return property.quaternionValue;
+                case SerializedPropertyType.Vector2Int:
+                    return property.vector2IntValue;
+                case SerializedPropertyType.Vector3Int:
+                    return property.vector3IntValue;
+                case SerializedPropertyType.RectInt:
+                    return property.rectIntValue;
+                case SerializedPropertyType.BoundsInt:
+                    return property.boundsIntValue;
+                case SerializedPropertyType.ManagedReference:
+                    return property.managedReferenceValue;
+                case SerializedPropertyType.Generic:
+                {
+                    object obj = property.serializedObject.targetObject;
+                    string[] propertyNames = property.propertyPath.Split('.');
+
+                    foreach (string name in propertyNames)
+                    {
+                        if (obj == null)
+                        {
+                            return null;
+                        }
+
+                        Type type = obj.GetType();
+                        if (
+                            !FieldProducersByType.TryGetValue(
+                                type,
+                                out Dictionary<string, Func<object, object>> fieldProducersByName
+                            )
+                        )
+                        {
+                            fieldProducersByName = new Dictionary<string, Func<object, object>>();
+                            FieldProducersByType[type] = fieldProducersByName;
+                        }
+
+                        if (
+                            !fieldProducersByName.TryGetValue(
+                                name,
+                                out Func<object, object> fieldProducer
+                            )
+                        )
+                        {
+                            FieldInfo field = type.GetField(
+                                name,
+                                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                            );
+                            fieldProducer =
+                                field == null
+                                    ? _ => null
+                                    : FieldAccessorFactory.CreateFieldGetter(field);
+                            fieldProducersByName[name] = fieldProducer;
+                        }
+
+                        obj = fieldProducer(obj);
+                    }
+
+                    return obj;
+                }
+                default:
+                    return null;
+            }
         }
 
         // Special handling for Gradients, since Unity doesn't expose gradientValue in SerializedProperty
         private static Gradient GetGradientValue(SerializedProperty property)
         {
-            PropertyInfo propertyInfo = typeof(SerializedProperty).GetProperty(
-                "gradientValue",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance
-            );
-            return propertyInfo?.GetValue(property) as Gradient;
+            return GradientProperty?.GetValue(property) as Gradient;
         }
     }
 #endif

--- a/Runtime/Extensions/SerializedPropertyExtensions.cs
+++ b/Runtime/Extensions/SerializedPropertyExtensions.cs
@@ -12,7 +12,7 @@
     {
         public static Func<object, object> CreateFieldGetter(FieldInfo field)
         {
-            var dynamicMethod = new DynamicMethod(
+            DynamicMethod dynamicMethod = new(
                 "Get" + field.Name,
                 typeof(object),
                 new[] { typeof(object) },

--- a/Runtime/Extensions/SerializedPropertyExtensions.cs
+++ b/Runtime/Extensions/SerializedPropertyExtensions.cs
@@ -1,0 +1,51 @@
+﻿namespace CommandTerminal.Extensions
+{
+#if UNITY_EDITOR
+    using System.Reflection;
+    using UnityEditor;
+    using UnityEngine;
+
+    public static class SerializedPropertyExtensions
+    {
+        public static object GetValue(this SerializedProperty property)
+        {
+            return property.propertyType switch
+            {
+                SerializedPropertyType.Integer => property.intValue,
+                SerializedPropertyType.Boolean => property.boolValue,
+                SerializedPropertyType.Float => property.floatValue,
+                SerializedPropertyType.String => property.stringValue,
+                SerializedPropertyType.Color => property.colorValue,
+                SerializedPropertyType.ObjectReference => property.objectReferenceValue,
+                SerializedPropertyType.LayerMask => (LayerMask)property.intValue,
+                SerializedPropertyType.Enum => property.enumValueIndex,
+                SerializedPropertyType.Vector2 => property.vector2Value,
+                SerializedPropertyType.Vector3 => property.vector3Value,
+                SerializedPropertyType.Vector4 => property.vector4Value,
+                SerializedPropertyType.Rect => property.rectValue,
+                SerializedPropertyType.Character => (char)property.intValue,
+                SerializedPropertyType.AnimationCurve => property.animationCurveValue,
+                SerializedPropertyType.Bounds => property.boundsValue,
+                SerializedPropertyType.Gradient => GetGradientValue(property),
+                SerializedPropertyType.Quaternion => property.quaternionValue,
+                SerializedPropertyType.Vector2Int => property.vector2IntValue,
+                SerializedPropertyType.Vector3Int => property.vector3IntValue,
+                SerializedPropertyType.RectInt => property.rectIntValue,
+                SerializedPropertyType.BoundsInt => property.boundsIntValue,
+                SerializedPropertyType.ManagedReference => property.managedReferenceValue,
+                _ => null,
+            };
+        }
+
+        // Special handling for Gradients, since Unity doesn't expose gradientValue in SerializedProperty
+        private static Gradient GetGradientValue(SerializedProperty property)
+        {
+            PropertyInfo propertyInfo = typeof(SerializedProperty).GetProperty(
+                "gradientValue",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance
+            );
+            return propertyInfo?.GetValue(property) as Gradient;
+        }
+    }
+#endif
+}

--- a/Runtime/Extensions/SerializedPropertyExtensions.cs.meta
+++ b/Runtime/Extensions/SerializedPropertyExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e0040db6342419aaca5231a62321a0b
+timeCreated: 1741627414

--- a/Runtime/Extensions/StringExtensions.cs
+++ b/Runtime/Extensions/StringExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace CommandTerminal.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool NeedsLowerInvariantConversion(this string input)
+        {
+            foreach (char inputCharacter in input)
+            {
+                if (char.ToLowerInvariant(inputCharacter) != inputCharacter)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Runtime/Extensions/StringExtensions.cs.meta
+++ b/Runtime/Extensions/StringExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: daa8d44d8f134080a4bdf94a333fdbc1
+timeCreated: 1741644236

--- a/Tests/Runtime/CommandArgTests.cs
+++ b/Tests/Runtime/CommandArgTests.cs
@@ -547,7 +547,7 @@
                 arg = new CommandArg(expected.ToString());
                 Assert.IsTrue(
                     arg.TryGet(out value),
-                    $"Failed to parse {expected} as char. Cleaned arg: '{arg.CleanedString}'"
+                    $"Failed to parse {expected} as char. Cleaned arg: '{arg.CleanedContents}'"
                 );
                 Assert.AreEqual(expected, value);
             }
@@ -557,7 +557,7 @@
 
             arg = new CommandArg("z");
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String[0], value);
+            Assert.AreEqual(arg.contents[0], value);
 
             arg = new CommandArg(nameof(char.MaxValue));
             Assert.IsTrue(arg.TryGet(out value));
@@ -2121,25 +2121,25 @@
             string expected = string.Empty;
             CommandArg arg = new(expected);
             Assert.IsTrue(arg.TryGet(out string value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             expected = "asdf";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             expected = "1111";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             expected = "1.3333";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             for (int i = 0; i < NumTries; ++i)
@@ -2147,34 +2147,34 @@
                 expected = System.Guid.NewGuid().ToString();
                 arg = new CommandArg(expected);
                 Assert.IsTrue(arg.TryGet(out value));
-                Assert.AreEqual(arg.String, value);
+                Assert.AreEqual(arg.contents, value);
                 Assert.AreEqual(expected, value);
             }
 
             expected = "#$$$__.azxfd87&*_&&&-={'|";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             // Check strings aren't sanitized
             expected = "   ";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             // Make sure string.Empty isn't resolved to ""
             expected = "Empty";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
 
             expected = "string.Empty";
             arg = new CommandArg(expected);
             Assert.IsTrue(arg.TryGet(out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
             Assert.AreEqual(expected, value);
         }
 
@@ -2469,14 +2469,14 @@
             Vector2 expected = (Vector2)value;
             Assert.IsTrue(
                 Approximately(expected.x, 1.2564f) && Approximately(expected.y, 3.6f),
-                $"Expected {expected} to be approximately {arg.String}"
+                $"Expected {expected} to be approximately {arg.contents}"
             );
 
             arg = new CommandArg("asdf");
             Assert.IsFalse(arg.TryGet(typeof(float), out value));
             Assert.IsFalse(arg.TryGet(typeof(int), out value));
             Assert.IsTrue(arg.TryGet(typeof(string), out value));
-            Assert.AreEqual(arg.String, value);
+            Assert.AreEqual(arg.contents, value);
         }
 
         [Test]

--- a/Tests/Runtime/Components/TestCommands.cs
+++ b/Tests/Runtime/Components/TestCommands.cs
@@ -1,6 +1,7 @@
 ﻿namespace DxCommandTerminal.Tests.Tests.Runtime.Components
 {
     using System;
+    using System.Diagnostics;
     using System.Linq;
     using Attributes;
     using CommandTerminal;
@@ -38,6 +39,39 @@
             Terminal.Shell?.RunCommand(
                 "log " + string.Join("a", Enumerable.Range(0, 1_000).Select(_ => string.Empty))
             );
+        }
+
+        [RegisterCommand(MinArgCount = 0, MaxArgCount = 1, Name = "perf-test")]
+        public static void RunPerformanceTest(CommandArg[] args)
+        {
+            if (args.Length != 1 || !args.Single().TryGet(out int count))
+            {
+                count = 1_000_000;
+            }
+
+            CommandShell shell = Terminal.Shell;
+            if (shell == null)
+            {
+                return;
+            }
+
+            // Construct log messages outside of timer
+            string[] logMessages = Enumerable.Range(0, count).Select(i => $"no-op {i}").ToArray();
+
+            Stopwatch timer = Stopwatch.StartNew();
+            try
+            {
+                for (int i = 0; i < count; ++i)
+                {
+                    shell.RunCommand("no-op");
+                    Terminal.Log(TerminalLogType.Input, logMessages[i]);
+                }
+            }
+            finally
+            {
+                timer.Stop();
+                shell.RunCommand($"log Performance test took {timer.ElapsedMilliseconds}ms");
+            }
         }
     }
 }

--- a/Tests/Runtime/TerminalTests.cs
+++ b/Tests/Runtime/TerminalTests.cs
@@ -1,0 +1,72 @@
+﻿namespace DxCommandTerminal.Tests.Tests.Runtime
+{
+    using System.Collections;
+    using CommandTerminal;
+    using Components;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TerminalTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            if (Terminal.Instance != null)
+            {
+                Object.Destroy(Terminal.Instance.gameObject);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator CleanConstruction()
+        {
+            yield return SpawnTerminal(resetStateOnInit: true);
+
+            Terminal terminal1 = Terminal.Instance;
+            Assert.IsNotNull(terminal1);
+            CommandShell shell = Terminal.Shell;
+            Assert.IsNotNull(shell);
+            CommandHistory history = Terminal.History;
+            Assert.IsNotNull(history);
+            CommandLog buffer = Terminal.Buffer;
+            Assert.IsNotNull(buffer);
+            CommandAutoComplete autoComplete = Terminal.AutoComplete;
+            Assert.IsNotNull(autoComplete);
+
+            yield return SpawnTerminal(resetStateOnInit: false);
+
+            Terminal terminal2 = Terminal.Instance;
+            Assert.IsNotNull(Terminal.Instance);
+            Assert.AreNotSame(terminal1, Terminal.Instance);
+            Assert.AreSame(shell, Terminal.Shell);
+            Assert.AreSame(history, Terminal.History);
+            Assert.AreSame(buffer, Terminal.Buffer);
+            Assert.AreSame(autoComplete, Terminal.AutoComplete);
+
+            yield return SpawnTerminal(resetStateOnInit: true);
+
+            Assert.IsNotNull(Terminal.Instance);
+            Assert.AreNotSame(terminal2, Terminal.Instance);
+            Assert.AreNotSame(terminal1, Terminal.Instance);
+            Assert.AreNotSame(shell, Terminal.Shell);
+            Assert.AreNotSame(shell, Terminal.Shell);
+            Assert.IsNotNull(Terminal.Shell);
+            Assert.AreNotSame(history, Terminal.History);
+            Assert.IsNotNull(Terminal.History);
+            Assert.AreNotSame(buffer, Terminal.Buffer);
+            Assert.IsNotNull(Terminal.Buffer);
+            Assert.AreNotSame(autoComplete, Terminal.AutoComplete);
+            Assert.IsNotNull(Terminal.AutoComplete);
+        }
+
+        internal static IEnumerator SpawnTerminal(bool resetStateOnInit)
+        {
+            GameObject go = new("Terminal", typeof(StartTracker), typeof(Terminal));
+            Terminal terminal = go.GetComponent<Terminal>();
+            terminal.resetStateOnInit = resetStateOnInit;
+            StartTracker startTracker = go.GetComponent<StartTracker>();
+            yield return new WaitUntil(() => startTracker.Started);
+        }
+    }
+}

--- a/Tests/Runtime/TerminalTests.cs.meta
+++ b/Tests/Runtime/TerminalTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d4441a9ba76d4696bb72512a7dfebe25
+timeCreated: 1741834502

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.wallstop-studios.dxcommandterminal",
-  "version": "1.0.0-rc15",
+  "version": "1.0.0-rc16",
   "displayName": "DxCommandTerminal",
   "description": "Wallstop Studios fork of Command Terminal for Unity",
   "dependencies": {},


### PR DESCRIPTION
&check; Terminal can now transition between OpenLarge and OpenSmall (added dynamic height)
&check; Added history buffer
&check; Optimized allocations
&check; Fixed a bug where input was being swallowed
&check; Fixed a bug where tab-completion under certain conditions was making text selection
&check; Fixed a bug where under certain conditions, input was or was not being cleared
&check; Fixed several bugs related to state initialization
&check; Added editor-only commands
&check; Renamed all in-built commands to be lisp-style
&check; Added ability to resize buffers in-place
&check; Added intelligent auto-tracking of properties using SerializedProperties (that can be turned on/off), enabling changes to editor properties to affect only relevant bits, allowing for live-editing of all properties
&check; Added intelligent quotation tech to command args